### PR TITLE
Post comments filter parameter default type added

### DIFF
--- a/Services/Post/Topluluk.Services.PostAPI/Controllers/PostCommentController.cs
+++ b/Services/Post/Topluluk.Services.PostAPI/Controllers/PostCommentController.cs
@@ -20,10 +20,10 @@ public class PostCommentController : BaseController
 
 
     [HttpGet("{id}/comments")]
-    public async Task<Response<List<CommentGetDto>>> GetComments(string id,string filter, int skip, int take)
+    public async Task<Response<List<CommentGetDto>>> GetComments(string id,string? filter, int skip, int take)
     {
         CommentFilter parsedFilter = CommentFilter.InteractionDescending;
-        if (Enum.IsDefined(typeof(CommentFilter), filter))
+        if (Enum.IsDefined(typeof(CommentFilter), filter ?? "InteractionDescending"))
         {
             Enum.TryParse<CommentFilter>(filter, out CommentFilter commentFilter);
             parsedFilter = commentFilter;


### PR DESCRIPTION
Post commentleri getirirken
 {{API_GATEWAY}}/post/65105bb71f6cec1980efec55/comments?filter=InteractionDescending&skip=0&take=10
endpointine atılan istekteki filter parametresi değeri defaulta çekildi ve parametre gönderme zorunluluğu kaldırıldı.